### PR TITLE
Variable name overrides

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,14 +8,32 @@
   version = "v0.19.0"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/go-yaml/yaml"
   packages = ["."]
   revision = "86f5ed62f8a0ee96bd888d2efdfd6d4fb100a4eb"
   version = "v2.2.0"
 
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "314e9620c0405ab3e0131fe8615649b605828ff9c6c136734cd6723fdac8162d"
+  inputs-digest = "ff055f97fb06764ccd88a02d56554e4def59a4d27e20072d586e6280c185be47"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,3 +5,7 @@
 [[constraint]]
   name = "github.com/Clever/configure"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.2"

--- a/main.go
+++ b/main.go
@@ -107,6 +107,24 @@ func main() {
 	}
 }
 
+var (
+	varOverrides []varOverride
+)
+
+type varOverride struct {
+	old string
+	new string
+}
+
+func init() {
+	varOverrides = []varOverride{
+		varOverride{
+			old: "Url",
+			new: "URL",
+		},
+	}
+}
+
 // FOO_BAR => FooBar
 // foo-bar => FooBar
 // foo => Foo
@@ -120,10 +138,16 @@ func toPublicVar(s string) string {
 		list = []string{s}
 	}
 
-	out := ""
+	titledVar := ""
 	for _, i := range list {
-		out += strings.Title(strings.ToLower(i))
+		titledVar += strings.Title(strings.ToLower(i))
 	}
+
+	out := titledVar
+	for _, override := range varOverrides {
+		out = strings.Replace(out, override.old, override.new, 1)
+	}
+
 	return out
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_toPublicVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "changes names with _",
+			input:    "foo_bar",
+			expected: "FooBar",
+		},
+		{
+			name:     "changes names with -",
+			input:    "foo-bar",
+			expected: "FooBar",
+		},
+		{
+			name:     "respects Url -> URL override",
+			input:    "foo_bar_url",
+			expected: "FooBarURL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := toPublicVar(tt.input)
+			assert.Equal(t, tt.expected, actual, tt.name)
+		})
+	}
+}
+
+func Test_toPrivateVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "changes names with _",
+			input:    "foo_bar",
+			expected: "fooBar",
+		},
+		{
+			name:     "changes names with -",
+			input:    "foo-bar",
+			expected: "fooBar",
+		},
+		{
+			name:     "respects Url -> URL override",
+			input:    "foo_bar_url",
+			expected: "fooBarURL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := toPrivateVar(tt.input)
+			assert.Equal(t, tt.expected, actual, tt.name)
+		})
+	}
+}


### PR DESCRIPTION
I've had a few linting errors along the lines of:
```
struct field MongoUrl should be MongoURL
```

Variable overrides fixes that. I'm not completely sure we should be changing names due to linting rules, but I figured this is a way to start!