### PR TITLE
Support optional env var

### DIFF
--- a/fixtures/launch1.expected
+++ b/fixtures/launch1.expected
@@ -25,8 +25,9 @@ type Dependencies struct {
 
 // Environment has environment variables and their values
 type Environment struct {
-	EnvVarA string
-	EnvVarB string
+	EnvVarA            string
+	EnvVarB            string
+	TracingAccessToken string
 }
 
 // InitLaunchConfig creates a LaunchConfig
@@ -45,8 +46,9 @@ func InitLaunchConfig() LaunchConfig {
 			WorkflowManager: workflowManager,
 		},
 		Env: Environment{
-			EnvVarA: requireEnvVar("ENV_VAR_A"),
-			EnvVarB: requireEnvVar("ENV_VAR_B"),
+			EnvVarA:            requireEnvVar("ENV_VAR_A"),
+			EnvVarB:            requireEnvVar("ENV_VAR_B"),
+			TracingAccessToken: os.Getenv("TRACING_ACCESS_TOKEN"),
 		},
 	}
 }

--- a/fixtures/launch1.yml
+++ b/fixtures/launch1.yml
@@ -1,6 +1,7 @@
 env:
-- ENV_VAR_A
-- ENV_VAR_B
+  - ENV_VAR_A
+  - ENV_VAR_B
+  - TRACING_ACCESS_TOKEN
 dependencies:
-- workflow-manager
-- dapple
+  - workflow-manager
+  - dapple

--- a/main.go
+++ b/main.go
@@ -58,9 +58,17 @@ func main() {
 	// Environment
 	envStruct := []Code{}
 	envInitDict := Dict{}
+	optionalEnvVars := []string{
+		// Not used in dev
+		"TRACING_ACCESS_TOKEN",
+	}
 	for _, s := range t.Env {
 		envStruct = append(envStruct, List(Id(toPublicVar(s))).String())
-		envInitDict[Id(toPublicVar(s))] = Id("requireEnvVar").Call(Lit(s))
+		if contains(optionalEnvVars, s) {
+			envInitDict[Id(toPublicVar(s))] = Id("os.Getenv").Call(Lit(s))
+		} else {
+			envInitDict[Id(toPublicVar(s))] = Id("requireEnvVar").Call(Lit(s))
+		}
 	}
 
 	f.Comment("Environment has environment variables and their values")
@@ -160,4 +168,13 @@ func toPrivateVar(s string) string {
 	}
 	out := toPublicVar(s)
 	return strings.ToLower(string(out[0])) + out[1:]
+}
+
+func contains(many []string, one string) bool {
+	for _, m := range many {
+		if m == one {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Allows some env vars to not be defined. Example use case is `TRACING_ACCESS_TOKEN`, which we set in prod but not dev.