### PR TITLE
add support for `aws:s3:write`

### DIFF
--- a/fixtures/launch1.expected
+++ b/fixtures/launch1.expected
@@ -33,8 +33,9 @@ type Environment struct {
 
 // AwsResources contains string IDs that will help for accessing various AWS resources
 type AwsResources struct {
-	MyBucket      string
-	AnotherBucket string
+	CommonBucket string
+	ReadBucket   string
+	WriteBucket  string
 }
 
 // InitLaunchConfig creates a LaunchConfig
@@ -49,8 +50,9 @@ func InitLaunchConfig() LaunchConfig {
 	}
 	return LaunchConfig{
 		AwsResources: AwsResources{
-			AnotherBucket: getS3NameByEnv("another-bucket"),
-			MyBucket:      getS3NameByEnv("my-bucket"),
+			CommonBucket: getS3NameByEnv("common-bucket"),
+			ReadBucket:   getS3NameByEnv("read-bucket"),
+			WriteBucket:  getS3NameByEnv("write-bucket"),
 		},
 		Deps: Dependencies{
 			Dapple:          dapple,

--- a/fixtures/launch1.expected
+++ b/fixtures/launch1.expected
@@ -33,9 +33,9 @@ type Environment struct {
 
 // AwsResources contains string IDs that will help for accessing various AWS resources
 type AwsResources struct {
-	CommonBucket string
-	ReadBucket   string
-	WriteBucket  string
+	S3ReadMe         string
+	S3ReadAndWriteMe string
+	S3WriteMe        string
 }
 
 // InitLaunchConfig creates a LaunchConfig
@@ -50,9 +50,9 @@ func InitLaunchConfig() LaunchConfig {
 	}
 	return LaunchConfig{
 		AwsResources: AwsResources{
-			CommonBucket: getS3NameByEnv("common-bucket"),
-			ReadBucket:   getS3NameByEnv("read-bucket"),
-			WriteBucket:  getS3NameByEnv("write-bucket"),
+			S3ReadAndWriteMe: getS3NameByEnv("read-and-write-me"),
+			S3ReadMe:         getS3NameByEnv("read-me"),
+			S3WriteMe:        getS3NameByEnv("write-me"),
 		},
 		Deps: Dependencies{
 			Dapple:          dapple,

--- a/fixtures/launch1.yml
+++ b/fixtures/launch1.yml
@@ -9,5 +9,8 @@ dependencies:
 aws:
   s3:
     read:
-      - my-bucket
-      - another-bucket
+      - common-bucket
+      - read-bucket
+    write:
+      - common-bucket
+      - write-bucket

--- a/fixtures/launch1.yml
+++ b/fixtures/launch1.yml
@@ -9,8 +9,8 @@ dependencies:
 aws:
   s3:
     read:
-      - common-bucket
-      - read-bucket
+      - read-me
+      - read-and-write-me
     write:
-      - common-bucket
-      - write-bucket
+      - write-me
+      - read-and-write-me

--- a/main.go
+++ b/main.go
@@ -126,10 +126,19 @@ func main() {
 	f.Comment("Environment has environment variables and their values")
 	f.Type().Id("Environment").Struct(envStruct...)
 
-	// AWS
+	// AWS Resources
 	awsStruct := []Code{}
 	awsInitDict := Dict{}
-	for _, a := range t.Aws.S3.Read {
+
+	s3Buckets := map[string]struct{}{}
+	for _, bucket := range t.Aws.S3.Read {
+		s3Buckets[bucket] = struct{}{}
+	}
+	for _, bucket := range t.Aws.S3.Write {
+		s3Buckets[bucket] = struct{}{}
+	}
+
+	for a := range s3Buckets {
 		awsStruct = append(awsStruct, List(Id(toPublicVar(a))).String())
 		awsInitDict[Id(strings.Title(toPublicVar(a)))] = Id(funcGetS3NameByEnv).Call(Lit(a))
 	}

--- a/main.go
+++ b/main.go
@@ -139,8 +139,9 @@ func main() {
 	}
 
 	for a := range s3Buckets {
-		awsStruct = append(awsStruct, List(Id(toPublicVar(a))).String())
-		awsInitDict[Id(strings.Title(toPublicVar(a)))] = Id(funcGetS3NameByEnv).Call(Lit(a))
+		name := "S3" + toPublicVar(a)
+		awsStruct = append(awsStruct, List(Id(name)).String())
+		awsInitDict[Id(name)] = Id(funcGetS3NameByEnv).Call(Lit(a))
 	}
 
 	f.Comment("AwsResources contains string IDs that will help for accessing various AWS resources")


### PR DESCRIPTION
- adds these resources
- dedups entries that appear in both `read` and `write`
- adds an `S3` prefix for readability and consistency with how we tended to name the env vars before