### PR TITLE
convert Api -> API

### DIFF
--- a/main.go
+++ b/main.go
@@ -237,6 +237,10 @@ func init() {
 			old: "Id",
 			new: "ID",
 		},
+		varOverride{
+			old: "Api",
+			new: "API",
+		},
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -28,9 +28,14 @@ func Test_toPublicVar(t *testing.T) {
 			expected: "FooBarURL",
 		},
 		{
-			name:     "respects Url -> URL override",
+			name:     "respects Id -> ID override",
 			input:    "foo_bar_id",
 			expected: "FooBarID",
+		},
+		{
+			name:     "respects Api -> API override",
+			input:    "foo_bar_api",
+			expected: "FooBarAPI",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
I wonder if there's a way to pull in / copy-paste the variable name overrides directly from golint?

```
/home/ubuntu/go/src/github.com/Clever/dapple/launch.go:36:2: struct field DdApiKey should be DdAPIKey
```