### PR TITLE
added a -d flag that allows users to override dependency names

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,10 @@ func main() {
 	flag.Parse()
 
 	// parsing through the list of overrides to make an original:new string map
-	overrideDependenciesList := strings.Split(*overrideDependenciesString, ",")
+	var overrideDependenciesList []string
+	if len(*overrideDependenciesString) > 3 {
+		overrideDependenciesList = strings.Split(*overrideDependenciesString, ",")
+	}
 	overrideDependenciesMap := make(map[string]string)
 
 	for _, s := range overrideDependenciesList {

--- a/main.go
+++ b/main.go
@@ -138,7 +138,7 @@ func main() {
 		Id("AwsResources"),
 	)
 
-	// parseOverrideDependencies parses the list of dependencies to be overwridden into a map
+	// parseOverrideDependencies parses the list of dependencies to be overwritten into a map
 	overrideDependenciesMap := parseOverrideDependencies(*overrideDependenciesString, t.Dependencies)
 
 	// Dependencies
@@ -211,20 +211,17 @@ func main() {
 		}
 		c := []Code{}
 
-		if replacementString, ok := overrideDependenciesMap[d]; ok {
-			c = []Code{
-				List(Id(toPrivateVar(d)), Err()).Op(":=").Qual(fmt.Sprintf("github.com/Clever/%s/gen-go/client", replacementString), "NewFromDiscovery").Call(),
-				If(Err().Op("!=").Nil()).Block(
-					Qual("log", "Fatalf").Call(List(Lit("discovery error: %s"), Err())),
-				),
-			}
-		} else {
-			c = []Code{
-				List(Id(toPrivateVar(d)), Err()).Op(":=").Qual(fmt.Sprintf("github.com/Clever/%s/gen-go/client", d), "NewFromDiscovery").Call(),
-				If(Err().Op("!=").Nil()).Block(
-					Qual("log", "Fatalf").Call(List(Lit("discovery error: %s"), Err())),
-				),
-			}
+		// checking to see if the dependency name has to be overwritten
+		replacementString, ok := overrideDependenciesMap[d]
+		if !ok {
+			replacementString = d
+		}
+
+		c = []Code{
+			List(Id(toPrivateVar(d)), Err()).Op(":=").Qual(fmt.Sprintf("github.com/Clever/%s/gen-go/client", replacementString), "NewFromDiscovery").Call(),
+			If(Err().Op("!=").Nil()).Block(
+				Qual("log", "Fatalf").Call(List(Lit("discovery error: %s"), Err())),
+			),
 		}
 
 		lines = append(lines, c...)

--- a/main.go
+++ b/main.go
@@ -60,14 +60,17 @@ func sortedKeys(m map[string]struct{}) []string {
 	return keys
 }
 
-func parseOverrideDependencies(overrideDependenciesString string, dependencies []string) map[string]string {
+func parseOverrideDependencies(overrideDependenciesString *string, dependencies []string) map[string]string {
 
 	// parsing through the list of overrides to make an original:new string map
-	var overrideDependenciesList []string
 
-	overrideDependenciesList = strings.Split(overrideDependenciesString, ",")
 	overrideDependenciesMap := make(map[string]string)
 
+	if overrideDependenciesString == nil || *overrideDependenciesString == "" {
+		return overrideDependenciesMap
+	}
+
+	overrideDependenciesList := strings.Split(*overrideDependenciesString, ",")
 	for _, overrideRule := range overrideDependenciesList {
 		depReplacementArr := strings.Split(overrideRule, ":")
 
@@ -91,17 +94,6 @@ func parseOverrideDependencies(overrideDependenciesString string, dependencies [
 	}
 
 	return overrideDependenciesMap
-}
-
-// helper function that takes in a flag name and returns true if the flag was passed as an argument
-func isFlagPassed(name string) bool {
-	found := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == name {
-			found = true
-		}
-	})
-	return found
 }
 
 func main() {
@@ -149,15 +141,7 @@ func main() {
 	)
 
 	// parseOverrideDependencies parses the list of dependencies to be overwritten into a map
-	var overrideDependenciesMap map[string]string
-
-	if isFlagPassed("d") {
-		if overrideDependenciesString != nil {
-			overrideDependenciesMap = parseOverrideDependencies(*overrideDependenciesString, t.Dependencies)
-		} else {
-			log.Fatal("invalid dependency override arguments provided.")
-		}
-	}
+	overrideDependenciesMap := parseOverrideDependencies(overrideDependenciesString, t.Dependencies)
 
 	// Dependencies
 	depsStruct := []Code{}


### PR DESCRIPTION
This PR servers to add a new -d flag that allows users to override dependency names to allow for version numbers, cases when the repo name is not the same as the app name, etc.

JIRA ticket: https://clever.atlassian.net/browse/INFRANG-4705?atlOrigin=eyJpIjoiZmI2ZjVmNjI1MTMxNGM2YzgxODFkMDc4MGFlNmM4MjgiLCJwIjoiaiJ9

Sample usage:
![Screen Shot 2022-07-06 at 11 15 26 AM](https://user-images.githubusercontent.com/40956188/177619934-df3f7ba7-9713-4b11-a182-c0efd32874a0.png)

the flag replaced 'district-view-service' with 'v2/district-view-service' 