### PR TITLE
Support versioned wagv9 repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ $(eval $(call golang-version-check,1.13))
 fixtures: build
 	rm -f fixtures/*.expected
 	./bin/launch-gen -p packagename -skip-dependency dependency-to-skip fixtures/launch1.yml > fixtures/launch1.expected
-	./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip fixtures/launch2.yml > fixtures/launch2.expected
+	./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml > fixtures/launch2.expected
 
 test: build $(PKGS)
 	diff <(./bin/launch-gen -p packagename -skip-dependency dependency-to-skip fixtures/launch1.yml) fixtures/launch1.expected
-	diff <(./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip fixtures/launch2.yml) fixtures/launch2.expected
+	diff <(./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml) fixtures/launch2.expected
 
 build:
 	$(call golang-build,$(PKG),$(EXECUTABLE))

--- a/fixtures/launch2.expected
+++ b/fixtures/launch2.expected
@@ -1,7 +1,7 @@
 package packagename
 
 import (
-	client1 "github.com/Clever/dapple/gen-go/client"
+	v5 "github.com/Clever/dapple/gen-go/client/v5"
 	logger "github.com/Clever/kayvee-go/v7/logger"
 	client "github.com/Clever/workflow-manager/gen-go/client"
 	"log"
@@ -20,7 +20,7 @@ type LaunchConfig struct {
 // Dependencies has clients for the service's dependencies
 type Dependencies struct {
 	WorkflowManager client.Client
-	Dapple          client1.Client
+	Dapple          v5.Client
 }
 
 // Environment has environment variables and their values
@@ -43,7 +43,7 @@ func InitLaunchConfig() LaunchConfig {
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}
-	dapple, err := client1.NewFromDiscovery(client1.WithLogger(logger.NewConcreteLogger("dapple-wagclient")))
+	dapple, err := v5.NewFromDiscovery(v5.WithLogger(logger.NewConcreteLogger("dapple-wagclient")))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}


### PR DESCRIPTION
Replacement strings were not supported for wagv9 repos, because the replacement strings were inserted before `/gen-go/client` like `/v9/gen-go/client`. But, versioned wag9 repos have the version after `client` i.e. `/gen-go/client/v9`.

This change makes it so for wagv9 repos, the replacement string is everything after `github.com/Clever`. 

Usage:
```
WAGV9

./bin/launch-gen --wagv9 -p packagename -d dapple:dapple/gen-go/client/v5 launch2.yml

PRE-WAGV9

./bin/launch-gen -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/v5 launch2.yml
```


