### PR TITLE
Add support for tracing for wagv9 clients

### DIFF
--- a/fixtures/launch2.expected
+++ b/fixtures/launch2.expected
@@ -3,7 +3,10 @@ package packagename
 import (
 	v5 "github.com/Clever/dapple/gen-go/client/v5"
 	logger "github.com/Clever/kayvee-go/v7/logger"
+	tracing "github.com/Clever/wag/tracing"
 	client "github.com/Clever/workflow-manager/gen-go/client"
+	trace "go.opentelemetry.io/otel/sdk/trace"
+	tracetest "go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"log"
 	"os"
 )
@@ -38,12 +41,15 @@ type AwsResources struct {
 }
 
 // InitLaunchConfig creates a LaunchConfig
-func InitLaunchConfig() LaunchConfig {
-	workflowManager, err := client.NewFromDiscovery(client.WithLogger(logger.NewConcreteLogger("workflow-manager-wagclient")))
+func InitLaunchConfig(exp *trace.SpanExporter) LaunchConfig {
+	if exp == nil {
+		exp = tracetest.NewNoopExporter()
+	}
+	workflowManager, err := client.NewFromDiscovery(client.WithLogger(logger.NewConcreteLogger("workflow-manager-wagclient")), client.WithExporter(exp), client.WithInstrumentor(tracing.InstrumentedTransport))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}
-	dapple, err := v5.NewFromDiscovery(v5.WithLogger(logger.NewConcreteLogger("dapple-wagclient")))
+	dapple, err := v5.NewFromDiscovery(v5.WithLogger(logger.NewConcreteLogger("dapple-wagclient")), v5.WithExporter(exp), v5.WithInstrumentor(tracing.InstrumentedTransport))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}


### PR DESCRIPTION
When tracing is enabled on a service, the wag clients take in two additional parameters to enable tracing. This PR adds in these two parameters for v9 clients. In the case that no exporter is provided, we default to a NoopExporter so there is no tracing enabled.