### PR TITLE
Fix nil pointer deref

### DIFF
--- a/fixtures/launch2.expected
+++ b/fixtures/launch2.expected
@@ -43,7 +43,8 @@ type AwsResources struct {
 // InitLaunchConfig creates a LaunchConfig
 func InitLaunchConfig(exp *trace.SpanExporter) LaunchConfig {
 	if exp == nil {
-		*exp = tracetest.NewNoopExporter()
+		exporter := tracetest.NewNoopExporter()
+		exp = &exporter
 	}
 	workflowManager, err := client.NewFromDiscovery(client.WithLogger(logger.NewConcreteLogger("workflow-manager-wagclient")), client.WithExporter(*exp), client.WithInstrumentor(tracing.InstrumentedTransport))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -216,7 +216,8 @@ func main() {
 	if *needWagV9Clients {
 		lines = append(lines, []Code{
 			If(Id("exp").Op("==").Nil().Block(
-				Id("*exp").Op("=").Qual("go.opentelemetry.io/otel/sdk/trace/tracetest", "NewNoopExporter").Call(),
+				Id("exporter").Op(":=").Qual("go.opentelemetry.io/otel/sdk/trace/tracetest", "NewNoopExporter").Call(),
+				Id("exp").Op("=").Id("&exporter"),
 			)),
 		}...)
 	}


### PR DESCRIPTION
*exp causes a deref even when just setting the value. this PR fixes that by setting it to a variable first