### PR TITLE
Remove --wagv9 flag since all clients should be v9 now and updated client creation to match new strategy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ $(eval $(call golang-version-check,1.13))
 fixtures: build
 	rm -f fixtures/*.expected
 	./bin/launch-gen -p packagename -skip-dependency dependency-to-skip fixtures/launch1.yml > fixtures/launch1.expected
-	./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml > fixtures/launch2.expected
+	./bin/launch-gen -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml > fixtures/launch2.expected
 
 test: build $(PKGS)
 	diff <(./bin/launch-gen -p packagename -skip-dependency dependency-to-skip fixtures/launch1.yml) fixtures/launch1.expected
-	diff <(./bin/launch-gen --wagv9 -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml) fixtures/launch2.expected
+	diff <(./bin/launch-gen -p packagename -skip-dependency dependency-to-skip -d dapple:dapple/gen-go/client/v5 fixtures/launch2.yml) fixtures/launch2.expected
 
 build:
 	$(call golang-build,$(PKG),$(EXECUTABLE))

--- a/fixtures/launch1.expected
+++ b/fixtures/launch1.expected
@@ -2,7 +2,10 @@ package packagename
 
 import (
 	client1 "github.com/Clever/dapple/gen-go/client"
+	v9 "github.com/Clever/wag/clientconfig/v9"
 	client "github.com/Clever/workflow-manager/gen-go/client"
+	trace "go.opentelemetry.io/otel/sdk/trace"
+	tracetest "go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"log"
 	"os"
 )
@@ -37,12 +40,18 @@ type AwsResources struct {
 }
 
 // InitLaunchConfig creates a LaunchConfig
-func InitLaunchConfig() LaunchConfig {
-	workflowManager, err := client.NewFromDiscovery()
+func InitLaunchConfig(exp *trace.SpanExporter) LaunchConfig {
+	var exporter trace.SpanExporter
+	if exp == nil {
+		exporter = tracetest.NewNoopExporter()
+	} else {
+		exporter = *exp
+	}
+	workflowManager, err := client.NewFromDiscovery(v9.WithTracing("workflow-manager", exporter))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}
-	dapple, err := client1.NewFromDiscovery()
+	dapple, err := client1.NewFromDiscovery(v9.WithTracing("dapple", exporter))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}

--- a/fixtures/launch2.expected
+++ b/fixtures/launch2.expected
@@ -2,8 +2,7 @@ package packagename
 
 import (
 	v5 "github.com/Clever/dapple/gen-go/client/v5"
-	logger "github.com/Clever/kayvee-go/v7/logger"
-	tracing "github.com/Clever/wag/tracing"
+	v9 "github.com/Clever/wag/clientconfig/v9"
 	client "github.com/Clever/workflow-manager/gen-go/client"
 	trace "go.opentelemetry.io/otel/sdk/trace"
 	tracetest "go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -48,11 +47,11 @@ func InitLaunchConfig(exp *trace.SpanExporter) LaunchConfig {
 	} else {
 		exporter = *exp
 	}
-	workflowManager, err := client.NewFromDiscovery(client.WithLogger(logger.NewConcreteLogger("workflow-manager-wagclient")), client.WithExporter(exporter), client.WithInstrumentor(tracing.InstrumentedTransport))
+	workflowManager, err := client.NewFromDiscovery(v9.WithTracing("workflow-manager", exporter))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}
-	dapple, err := v5.NewFromDiscovery(v5.WithLogger(logger.NewConcreteLogger("dapple-wagclient")), v5.WithExporter(exporter), v5.WithInstrumentor(tracing.InstrumentedTransport))
+	dapple, err := v5.NewFromDiscovery(v9.WithTracing("dapple", exporter))
 	if err != nil {
 		log.Fatalf("discovery error: %s", err)
 	}


### PR DESCRIPTION
1. Since all services are on wagv9, I've made the wagv9 behavior the default. If for some reason someone wants to use a pre-wagv9 service with launch-gen they will need to use an older version of launch-gen. Since we don't heavily invest in launch-gen, I think we should minimize maintenance and complexity on our end.
2. Update the client creation to use client config and thus the new wag client API from [here](https://github.com/Clever/wag/pull/455)