### PR TITLE
[INFRA-319] refactor common methods to shared.go

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Clever/eng-infra

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 - [ ] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"
 
-## JIRA
-[Link to JIRA](insert url here)
+## Linear
+[Link to Linear](insert url here)
 
 ## Overview
 (insert PR description here)

--- a/codegen.go
+++ b/codegen.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"log"
+	"strings"
+
+	"github.com/dave/jennifer/jen"
+)
+
+const wagClientSuffix = "/gen-go/client"
+
+func cleverImportPath(depName, pathSuffix string) string {
+	return "github.com/Clever/" + depName + pathSuffix
+}
+
+type varOverride struct {
+	old string
+	new string
+}
+
+var varOverrides = []varOverride{
+	{old: "Url", new: "URL"},
+	{old: "Id", new: "ID"},
+	{old: "Api", new: "API"},
+}
+
+// FOO_BAR => FooBar
+// foo-bar => FooBar
+// foo.bar => FooBar
+// foo => Foo
+func toPublicVar(s string) string {
+	s = strings.ReplaceAll(strings.ToUpper(s), ".", "_")
+	s = strings.ReplaceAll(strings.ToUpper(s), "-", "_")
+	list := strings.Split(s, "_")
+
+	titledVar := ""
+	for _, word := range list {
+		word = strings.ToLower(word)
+		if word != "" {
+			titledVar += strings.ToUpper(word[:1]) + word[1:]
+		}
+	}
+
+	out := titledVar
+	for _, override := range varOverrides {
+		out = strings.Replace(out, override.old, override.new, 1)
+	}
+
+	return out
+}
+
+// FOO_BAR => fooBar
+// foo-bar => fooBar
+// foo => foo
+func toPrivateVar(s string) string {
+	if s == "" {
+		return s
+	}
+	out := toPublicVar(s)
+	return strings.ToLower(string(out[0])) + out[1:]
+}
+
+func contains(many []string, one string) bool {
+	for _, m := range many {
+		if m == one {
+			return true
+		}
+	}
+	return false
+}
+
+func parseOverrideDependencies(overrideDependenciesString *string, dependencies []string) map[string]string {
+	overrideDependenciesMap := make(map[string]string)
+
+	if overrideDependenciesString == nil || *overrideDependenciesString == "" {
+		return overrideDependenciesMap
+	}
+
+	overrideDependenciesList := strings.Split(*overrideDependenciesString, ",")
+	for _, overrideRule := range overrideDependenciesList {
+		depReplacementArr := strings.Split(overrideRule, ":")
+
+		if len(depReplacementArr) != 2 || depReplacementArr[1] == "" {
+			log.Fatal("usage: invalid formatting for the -d flag")
+		}
+
+		if !contains(dependencies, depReplacementArr[0]) {
+			log.Fatal(depReplacementArr[0], " is not a dependency specified in the provided yaml file")
+		}
+
+		overrideDependenciesMap[depReplacementArr[0]] = depReplacementArr[1]
+	}
+
+	return overrideDependenciesMap
+}
+
+func generateDependencies(f *jen.File, deps []string, skip map[string]bool, overrides map[string]string) (jen.Dict, []jen.Code) {
+	depsStruct := []jen.Code{}
+	depsInitDict := jen.Dict{}
+	for _, d := range deps {
+		if _, ok := skip[d]; ok {
+			continue
+		}
+		importPackage, pathSuffix := resolveDepImport(d, overrides)
+		depsStruct = append(depsStruct, jen.Id(toPublicVar(d)).Qual(cleverImportPath(importPackage, pathSuffix), "Client"))
+		depsInitDict[jen.Id(toPublicVar(d))] = jen.Id(toPrivateVar(d))
+	}
+	f.Comment("Dependencies has clients for the service's dependencies")
+	f.Type().Id("Dependencies").Struct(depsStruct...)
+	return depsInitDict, buildDepInitLines(deps, skip, overrides)
+}
+
+func resolveDepImport(dep string, overrides map[string]string) (depName, pathSuffix string) {
+	if override, hasOverride := overrides[dep]; hasOverride {
+		return override, ""
+	}
+	return dep, wagClientSuffix
+}
+
+func buildDepInitLines(deps []string, skip map[string]bool, overrides map[string]string) []jen.Code {
+	atLeastOneDep := false
+	for _, d := range deps {
+		if _, skipped := skip[d]; !skipped {
+			atLeastOneDep = true
+			break
+		}
+	}
+	if !atLeastOneDep {
+		return []jen.Code{}
+	}
+
+	initLines := []jen.Code{
+		jen.Id("var exporter ").Qual("go.opentelemetry.io/otel/sdk/trace", "SpanExporter"),
+		jen.If(jen.Id("exp").Op("==").Nil().Block(
+			jen.Id("exporter").Op("=").Qual("go.opentelemetry.io/otel/sdk/trace/tracetest", "NewNoopExporter").Call(),
+		)).Else().Block(
+			jen.Id("exporter").Op("=").Id("*exp"),
+		),
+	}
+
+	for _, d := range deps {
+		if _, ok := skip[d]; ok {
+			continue
+		}
+		depName, pathSuffix := resolveDepImport(d, overrides)
+		initLines = append(initLines, []jen.Code{
+			jen.List(jen.Id(toPrivateVar(d)), jen.Err()).Op(":=").
+				Qual(cleverImportPath(depName, pathSuffix), "NewFromDiscovery").
+				Call(jen.Qual("github.com/Clever/wag/clientconfig/v9", "WithTracing").Call(jen.Lit(d), jen.Id("exporter"))),
+			jen.If(jen.Err().Op("!=").Nil()).Block(
+				jen.Qual("log", "Fatalf").Call(jen.List(jen.Lit("discovery error: %s"), jen.Err())),
+			),
+		}...)
+	}
+
+	return initLines
+}
+
+func emitRequireEnvVar(f *jen.File) {
+	f.Comment(`requireEnvVar exits the program immediately if an env var is not set`)
+	f.Func().Id("requireEnvVar").Params(jen.Id("s").String()).String().Block(
+		jen.List(jen.Id("val"), jen.Id("present")).Op(":=").Qual("os", "LookupEnv").Call(jen.Id("s")),
+		jen.If(jen.Op("!").Id("present")).Block(
+			jen.Qual("log", "Fatalf").Call(jen.List(jen.Lit("env var %s is not defined"), jen.Id("s"))),
+		),
+		jen.Return(jen.Id("val")),
+	)
+}

--- a/main.go
+++ b/main.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
-	"strings"
 
 	. "github.com/dave/jennifer/jen"
 	"github.com/go-yaml/yaml"
@@ -26,28 +24,6 @@ type LaunchYML struct {
 	} `json:"aws"`
 }
 
-type flagsSet map[string]bool
-
-func (fs *flagsSet) String() string {
-	if fs == nil {
-		return "nil"
-	}
-
-	values := make([]string, len(*fs))
-	i := 0
-	for k := range *fs {
-		values[i] = k
-		i++
-	}
-
-	return fmt.Sprintf("%s", values)
-}
-
-func (fs *flagsSet) Set(value string) error {
-	(*fs)[value] = true
-	return nil
-}
-
 const (
 	funcGetS3NameByEnv = "getS3NameByEnv"
 )
@@ -61,48 +37,15 @@ func sortedKeys(m map[string]struct{}) []string {
 	return keys
 }
 
-func parseOverrideDependencies(overrideDependenciesString *string, dependencies []string) map[string]string {
-
-	// parsing through the list of overrides to make an original:new string map
-
-	overrideDependenciesMap := make(map[string]string)
-
-	if overrideDependenciesString == nil || *overrideDependenciesString == "" {
-		return overrideDependenciesMap
-	}
-
-	overrideDependenciesList := strings.Split(*overrideDependenciesString, ",")
-	for _, overrideRule := range overrideDependenciesList {
-		depReplacementArr := strings.Split(overrideRule, ":")
-
-		if len(depReplacementArr) != 2 || depReplacementArr[1] == "" {
-			log.Fatal("usage: invalid formatting for the -d flag")
-		}
-
-		flag := 0
-		for _, d := range dependencies {
-			if d == depReplacementArr[0] {
-				flag = 1
-				break
-			}
-		}
-
-		if flag == 0 {
-			log.Fatal(depReplacementArr[0], " is not a dependency specified in the provided yaml file")
-		}
-
-		overrideDependenciesMap[depReplacementArr[0]] = depReplacementArr[1]
-	}
-
-	return overrideDependenciesMap
-}
-
 func main() {
 	t := LaunchYML{}
 	packageName := flag.String("p", "main", "optional package name")
 	outputFile := flag.String("o", "", "optional output to file. Default is stdout")
-	var skipDependencies flagsSet = map[string]bool{}
-	flag.Var(&skipDependencies, "skip-dependency", "Dependency to skip generating wag clients. Can be added mulitple times e.g. -skip-dependency a -skip-dependency b")
+	skipDependencies := map[string]bool{}
+	flag.Func("skip-dependency", "Dependency to skip generating wag clients. Can be added multiple times e.g. -skip-dependency a -skip-dependency b", func(s string) error {
+		skipDependencies[s] = true
+		return nil
+	})
 	overrideDependenciesString := flag.String("d", "", "Dependency name to override. You can provide multiple dependencies in the format dep1:replacementDep1,dep2:replacementDep2,...")
 	flag.Parse()
 
@@ -146,29 +89,7 @@ func main() {
 	overrideDependenciesMap := parseOverrideDependencies(overrideDependenciesString, t.Dependencies)
 
 	// Dependencies
-	depsStruct := []Code{}
-	depsInitDict := Dict{}
-	for _, d := range t.Dependencies {
-		if _, ok := skipDependencies[d]; ok {
-			continue
-		}
-
-		// with wagv9 onwards the following string is after the service name in the path
-		depPathSuffix := "/gen-go/client"
-
-		importPackage, hasOverride := overrideDependenciesMap[d]
-		if hasOverride {
-			// Clients have the version after '/client', so the '/gen-go/client' must be part of the path override already
-			depPathSuffix = ""
-		} else {
-			importPackage = d
-		}
-
-		depsStruct = append(depsStruct, Id(strings.Title(toPublicVar(d))).Qual(fmt.Sprintf("github.com/Clever/%s%s", importPackage, depPathSuffix), "Client"))
-		depsInitDict[Id(strings.Title(toPublicVar(d)))] = Id(toPrivateVar(d))
-	}
-	f.Comment("Dependencies has clients for the service's dependencies")
-	f.Type().Id("Dependencies").Struct(depsStruct...)
+	depsInitDict, depInitLines := generateDependencies(f, t.Dependencies, skipDependencies, overrideDependenciesMap)
 
 	// Environment
 	envStruct := []Code{}
@@ -224,53 +145,7 @@ func main() {
 	////////////////////
 	// InitLaunchConfig() function
 	////////////////////
-	atLeastOneDep := false
-	for _, d := range t.Dependencies {
-		if _, skipped := skipDependencies[d]; !skipped {
-			atLeastOneDep = true
-			break
-		}
-	}
-	lines := []Code{}
-	if atLeastOneDep {
-		lines = append(lines, []Code{
-			Id("var exporter ").Qual("go.opentelemetry.io/otel/sdk/trace", "SpanExporter"),
-			If(Id("exp").Op("==").Nil().Block(
-				Id("exporter").Op("=").Qual("go.opentelemetry.io/otel/sdk/trace/tracetest", "NewNoopExporter").Call(),
-			)).Else().Block(
-				Id("exporter").Op("=").Id("*exp"),
-			),
-		}...)
-	}
-	// Setup a wag client for each dependency
-	for _, d := range t.Dependencies {
-		if _, ok := skipDependencies[d]; ok {
-			continue
-		}
-
-		// with wagv9 onwards the following string is after the service name in the path
-		depPathSuffix := "/gen-go/client"
-
-		// checking to see if the dependency name has to be overwritten
-		depName, hasOverride := overrideDependenciesMap[d]
-		if hasOverride {
-			// Clients have the version after '/client', so the '/gen-go/client' must be part of the path override already
-			depPathSuffix = ""
-		} else {
-			depName = d
-		}
-
-		c := []Code{
-			List(Id(toPrivateVar(d)), Err()).Op(":=").
-				Qual(fmt.Sprintf("github.com/Clever/%s%s", depName, depPathSuffix), "NewFromDiscovery").
-				Call(Qual("github.com/Clever/wag/clientconfig/v9", "WithTracing").Call(Lit(d), Id("exporter"))),
-			If(Err().Op("!=").Nil()).Block(
-				Qual("log", "Fatalf").Call(List(Lit("discovery error: %s"), Err())),
-			),
-		}
-
-		lines = append(lines, c...)
-	}
+	lines := depInitLines
 
 	// setup external url discovery for each dependency
 	for _, s := range t.ExternalUrlUsage {
@@ -301,14 +176,7 @@ func main() {
 
 	f.Func().Id("InitLaunchConfig").Params(initLaunchConfigParams...).Id("LaunchConfig").Block(lines...)
 
-	f.Comment(`requireEnvVar exits the program immediately if an env var is not set`)
-	f.Func().Id("requireEnvVar").Params(Id("s").String()).String().Block(
-		List(Id("val"), Id("present")).Op(":=").Qual("os", "LookupEnv").Call(Id("s")),
-		If(Op("!").Id("present")).Block(
-			Qual("log", "Fatalf").Call(List(Lit("env var %s is not defined"), Id("s"))),
-		),
-		Return(Id("val")),
-	)
+	emitRequireEnvVar(f)
 
 	f.Comment(`getS3NameByEnv adds "-dev" to an env var name unless we're in "production" deploy env, and appends _POD_ACCOUNT if the account is in podAccountSuffixMap`)
 	f.Comment(`We check both DEPLOY_ENV and _DEPLOY_ENV env vars, which are injected by our deployment system for Lambda and non-Lambda deployments, respectively`)
@@ -343,74 +211,6 @@ func main() {
 	}
 }
 
-var (
-	varOverrides        []varOverride
-	podAccountSuffixMap = map[string]bool{
-		"585008086734": true, // dev workload account
-	}
-)
-
-type varOverride struct {
-	old string
-	new string
-}
-
-func init() {
-	// Golint complains if certain strings are not capitalized
-	varOverrides = []varOverride{
-		varOverride{
-			old: "Url",
-			new: "URL",
-		},
-		varOverride{
-			old: "Id",
-			new: "ID",
-		},
-		varOverride{
-			old: "Api",
-			new: "API",
-		},
-	}
-}
-
-// FOO_BAR => FooBar
-// foo-bar => FooBar
-// foo.bar => FooBar
-// foo => Foo
-func toPublicVar(s string) string {
-	s = strings.ReplaceAll(strings.ToUpper(s), ".", "_")
-	s = strings.ReplaceAll(strings.ToUpper(s), "-", "_")
-	list := strings.Split(s, "_")
-
-	titledVar := ""
-	for _, i := range list {
-		titledVar += strings.Title(strings.ToLower(i))
-	}
-
-	out := titledVar
-	for _, override := range varOverrides {
-		out = strings.Replace(out, override.old, override.new, 1)
-	}
-
-	return out
-}
-
-// FOO_BAR => fooBar
-// foo-bar => fooBar
-// foo => foo
-func toPrivateVar(s string) string {
-	if s == "" {
-		return s
-	}
-	out := toPublicVar(s)
-	return strings.ToLower(string(out[0])) + out[1:]
-}
-
-func contains(many []string, one string) bool {
-	for _, m := range many {
-		if m == one {
-			return true
-		}
-	}
-	return false
+var podAccountSuffixMap = map[string]bool{
+	"585008086734": true, // dev workload account
 }


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[Link to JIRA](https://linear.app/clever/issue/INFRA-319/update-dependency-client-creation-external-url-usage-to-support-k8s)

## Overview
First part of the launch-gen re-write to support kubernetes-deployed apps that use `values.yaml` instead of `launch.yaml`. The re-write will have a total of 3 parts:
1. Extract common methods out of `main.go` into a central `codegen.go` file
2. Extract Fargate-specific logic to a `fargate.go` file
3. Implement Kubernetes-specific logic in  a `kubernetes.go` files. Consuming applications will toggle between the Fargate and Kubernetes paths by providing a `--kubernetes` flag. The Fargate path will be the default. 

After the Kubernetes migration is complete `fargate.go` and the `--kubernetes` flag can be removed.

**main.go changes**
* copy/paste common methods into `codegen.go`
* Replaced `flagsSet` with more modern flag.Func 

**codegen.go common methods**
* `toPublicVar` / `toPrivateVar` / `contains` — name formatting utilities
* `parseOverrideDependencies` — `-d` flag parsing
* `generateDependencies` / `resolveDepImport` / `buildDepInitLines` — dependency struct + client init codegen. Refactored original code to improve readability
* `emitRequireEnvVar` — emits the `requireEnvVar` helper into generated files

## Testing
* Built launch-go binary on this feature branch: `go build -o /tmp/launch-gen-new .`
* Built launch-go binary for the master branch:
```
git show master:main.go > /tmp/launch-gen-master-build/main.go
git show master:go.mod  > /tmp/launch-gen-master-build/go.mod
cp -r ./vendor          /tmp/launch-gen-master-build/vendor
go build -o /tmp/launch-gen-master /tmp/launch-gen-master-build
```
* Ran new and old launch-gen command against all launch files in  https://github.com/Clever/google-classroom-rostering  and verified no differences. Repo was chosen since it had lots of examples with externalUrlUsage, aws, dependencies, env variables, dependency skipping, etc
```
example: 
diff \
  <(/tmp/launch-gen-master /Users/diana.martschenko/go/src/github.com/Clever/google-classroom-rostering/launch/google-classroom-launch/gcr-list-provisioned-courses.yml) \
  <(/tmp/launch-gen-new    /Users/diana.martschenko/go/src/github.com/Clever/google-classroom-rostering/launch/launch/gcr-list-provisioned-courses.yml)
```

## Rollout
* Verified backwards compatibility. Net new apps built on Fargate will have the same functionality
* Existing apps will not update to the new version
* Kubernetes migration skill will be updated to have apps use the final version after all 3 components are pushed. 

## Rollback
* Consuming apps should pin to a previous version